### PR TITLE
プロローグとエピローグは発言制限なしにする

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <version>0.0.1-SNAPSHOT</version>
     <name>howling-wolf</name>
     <packaging>jar</packaging>
-    <description>忙しい人のためのオプションルールを盛り込んだ人狼がプレイできるサイトのAPI</description>
+    <description>人狼ゲームがプレイできるサイトのAPI</description>
 
     <properties>
         <java.version>1.8</java.version>

--- a/src/main/kotlin/com/ort/howlingwolf/domain/model/myself/participant/VillageSayRestrictSituation.kt
+++ b/src/main/kotlin/com/ort/howlingwolf/domain/model/myself/participant/VillageSayRestrictSituation.kt
@@ -19,7 +19,7 @@ data class VillageSayRestrictSituation(
     ) : this(
         isRestricted = village.setting.rules.messageRestrict.restrict(messageType) != null,
         maxCount = village.setting.rules.messageRestrict.restrict(messageType)?.count,
-        remainingCount = village.setting.rules.messageRestrict.restrict(messageType)?.remainingCount(latestDayMessageList),
+        remainingCount = village.setting.rules.messageRestrict.restrict(messageType)?.remainingCount(village.status.toCdef(), latestDayMessageList),
         maxLength = village.setting.rules.messageRestrict.restrict(messageType)?.length ?: MessageContent.defaultLengthMax,
         maxLine = village.setting.rules.messageRestrict.restrict(messageType)?.line ?: MessageContent.lineMax
     )

--- a/src/main/kotlin/com/ort/howlingwolf/domain/model/village/Village.kt
+++ b/src/main/kotlin/com/ort/howlingwolf/domain/model/village/Village.kt
@@ -253,7 +253,7 @@ data class Village(
      */
     fun assertMessageRestrict(messageContent: MessageContent, latestDayMessageList: List<Message>) {
         val restrict = setting.rules.messageRestrict.restrict(messageContent.type.toCdef()) ?: return // 制限なし
-        restrict.assertSay(messageContent, latestDayMessageList)
+        restrict.assertSay(messageContent, status.toCdef(), latestDayMessageList)
     }
 
     /** 村として能力を行使できるか */

--- a/src/main/kotlin/com/ort/howlingwolf/domain/model/village/setting/VillageMessageRestrict.kt
+++ b/src/main/kotlin/com/ort/howlingwolf/domain/model/village/setting/VillageMessageRestrict.kt
@@ -1,5 +1,6 @@
 package com.ort.howlingwolf.domain.model.village.setting
 
+import com.ort.dbflute.allcommon.CDef
 import com.ort.howlingwolf.domain.model.message.Message
 import com.ort.howlingwolf.domain.model.message.MessageContent
 import com.ort.howlingwolf.domain.model.message.MessageType
@@ -11,14 +12,17 @@ data class VillageMessageRestrict(
     val length: Int,
     val line: Int = MessageContent.lineMax
 ) {
-    fun assertSay(messageContent: MessageContent, latestDayMessageList: List<Message>) {
+    fun assertSay(messageContent: MessageContent, cdefVillageStatus: CDef.VillageStatus, latestDayMessageList: List<Message>) {
         // 回数
-        if (remainingCount(latestDayMessageList) <= 0) throw HowlingWolfBusinessException("発言残り回数が0回です")
+        if (remainingCount(cdefVillageStatus, latestDayMessageList) <= 0) throw HowlingWolfBusinessException("発言残り回数が0回です")
         // 文字数
         messageContent.assertMessageLength(length)
     }
 
-    fun remainingCount(latestDayMessageList: List<Message>): Int {
+    fun remainingCount(cdefVillageStatus: CDef.VillageStatus, latestDayMessageList: List<Message>): Int {
+        if (cdefVillageStatus == CDef.VillageStatus.プロローグ || cdefVillageStatus == CDef.VillageStatus.エピローグ) {
+            return count // プロローグ、エピローグでは制限なし状態にする
+        }
         val alreadySayCount = latestDayMessageList.count { it.content.type.toCdef() == type.toCdef() }
         return count - alreadySayCount
     }


### PR DESCRIPTION
# 背景
プロローグエピローグも20発言しかできない

# 実装内容
掲題通り

# テスト内容
junit test, 画面での動作確認を行った